### PR TITLE
Feature/group camera

### DIFF
--- a/project/arena-mode/Arena.tscn
+++ b/project/arena-mode/Arena.tscn
@@ -10,7 +10,7 @@
 [ext_resource path="res://hud/blur.tscn" type="PackedScene" id=8]
 [ext_resource path="res://hud/ArenaHUD.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/white.png" type="Texture" id=10]
-[ext_resource path="res://camera/GroupCamera.gd" type="Script" id=11]
+[ext_resource path="res://camera/Camera.gd" type="Script" id=11]
 
 [sub_resource type="Shader" id=1]
 
@@ -193,10 +193,6 @@ max_offset_y = 250
 violence = 0.3
 dec_ratio = 1.2
 exponent = 2
-min_zoom = 1
-max_zoom = 0.75
-zooming_dist = 800
-min_dist = 100
 
 
 [editable path="Players/Player1"]

--- a/project/arena-mode/Arena.tscn
+++ b/project/arena-mode/Arena.tscn
@@ -10,8 +10,7 @@
 [ext_resource path="res://hud/blur.tscn" type="PackedScene" id=8]
 [ext_resource path="res://hud/ArenaHUD.tscn" type="PackedScene" id=9]
 [ext_resource path="res://assets/white.png" type="Texture" id=10]
-[ext_resource path="res://camera/Camera.gd" type="Script" id=11]
-
+[ext_resource path="res://camera/GroupCamera.gd" type="Script" id=11]
 
 [sub_resource type="Shader" id=1]
 
@@ -46,10 +45,11 @@ _sections_unfolded = [ "shader_param" ]
 flags = 4
 load_path = "res://.import/white.png-936ea7d0834e1e21adf362ba74ff2135.stex"
 
-[node name="Main" type="Node2D"]
+[node name="Main" type="Node2D" index="0"]
 
 script = ExtResource( 1 )
 _sections_unfolded = [ "Pause", "Z Index" ]
+stage_num = 10
 use_keyboard = false
 keyboard_id = 0
 
@@ -193,6 +193,10 @@ max_offset_y = 250
 violence = 0.3
 dec_ratio = 1.2
 exponent = 2
+min_zoom = 1
+max_zoom = 0.75
+zooming_dist = 800
+min_dist = 100
 
 
 [editable path="Players/Player1"]

--- a/project/camera/GroupCamera.gd
+++ b/project/camera/GroupCamera.gd
@@ -1,0 +1,34 @@
+extends "res://camera/Camera.gd"
+
+# All chidren of the Camera2D containing this script should be nodes inhereting from Node2D
+
+onready var children = get_children()
+
+
+func _process(delta):
+	set_position( get_average_position() )
+
+
+func get_average_position():
+	var avrg = children[0].get_position()
+	
+	for i in range(1, children.size()):
+		avrg += children[i].get_position()
+	avrg /= children.size()
+	
+	return avrg
+
+
+func get_max_distance():
+	var max_dist = Vector2(0, 0)
+	
+	for i in range(children.size() - 1):
+		for j in range(i + 1, children.size()):
+			var dist = children[i].get_position().distance_to( children[j].get_position() )
+			
+			if dist.x > max_dist.x:
+				max_dist.x = dist.x
+			if dist.y > max_dist.y:
+				max_dist.y = dist.y
+	
+	return max_dist

--- a/project/camera/GroupCamera.gd
+++ b/project/camera/GroupCamera.gd
@@ -11,8 +11,7 @@ export (int)var min_dist = 100 # the camera will reach max_zoom at this dist
 var children
 
 func _ready():
-	var players = get_parent().get_node("Players")
-	set_children(players.get_children())
+	set_physics_process(false)
 
 
 func _physics_process(delta):
@@ -60,3 +59,4 @@ func get_max_distance():
 
 func set_children(children):
 	self.children = children
+	set_physics_process(true)

--- a/project/camera/GroupCamera.gd
+++ b/project/camera/GroupCamera.gd
@@ -1,12 +1,34 @@
 extends "res://camera/Camera.gd"
 
 # All chidren of the Camera2D containing this script should be nodes inhereting from Node2D
+# Needs a call of set_children() to work
 
-onready var children = get_children()
+export (float)var min_zoom = 1
+export (float)var max_zoom = 0.5
+export (int)var zooming_dist = 1000 # the camera will start zooming in when max_dist < zooming_dist
+export (int)var min_dist = 100 # the camera will reach max_zoom at this dist
+
+var children
+
+func _ready():
+	var players = get_parent().get_node("Players")
+	set_children(players.get_children())
 
 
-func _process(delta):
+func _physics_process(delta):
+	var max_dist = get_max_distance()
+	
+	if max_dist.x < zooming_dist && max_dist.x > min_dist:
+		adjust_zoom(max_dist)
+	
 	set_position( get_average_position() )
+
+
+func adjust_zoom(dist):
+	var weight_x = (dist.x - zooming_dist) / -(zooming_dist - min_dist)
+	var x = lerp(min_zoom, max_zoom, weight_x)
+	
+	set_zoom(Vector2(x, x))
 
 
 func get_average_position():
@@ -24,7 +46,9 @@ func get_max_distance():
 	
 	for i in range(children.size() - 1):
 		for j in range(i + 1, children.size()):
-			var dist = children[i].get_position().distance_to( children[j].get_position() )
+			var pos1 = children[i].get_position()
+			var pos2 = children[j].get_position()
+			var dist = Vector2(abs(pos1.x - pos2.x), abs(pos1.y - pos2.y))
 			
 			if dist.x > max_dist.x:
 				max_dist.x = dist.x
@@ -32,3 +56,7 @@ func get_max_distance():
 				max_dist.y = dist.y
 	
 	return max_dist
+
+
+func set_children(children):
+	self.children = children


### PR DESCRIPTION
GroupCamera zooms in when its designated children (not actually child nodes necessarily) move closer together, while mantaining the shaking functionality of regular camera.