### PR TITLE
Fix outline shaders missing textures

### DIFF
--- a/project/gameplay/objects/obstacles/float-objects/outline_floaters.tres
+++ b/project/gameplay/objects/obstacles/float-objects/outline_floaters.tres
@@ -1,4 +1,10 @@
-[gd_resource type="ShaderMaterial" load_steps=2 format=2]
+[gd_resource type="ShaderMaterial" load_steps=3 format=2]
+
+[sub_resource type="GDScript" id=2]
+script/source = "func _init():
+	self.shader.set_default_texture_param(\"distortion\", load(\"res://assets/images/effects/WaterDistortion.png\"))
+	self.shader.set_default_texture_param(\"noise\", load(\"res://assets/images/effects/noise.png\"))
+"
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -53,3 +59,4 @@ shader_param/wave_color = Color( 0.701961, 0.909804, 0.980392, 1 )
 shader_param/wave_scroll_speed = Vector2( 0.02, 0.01 )
 shader_param/distortion_strength = 0.3
 shader_param/aa_factor = 0.04
+script = SubResource( 2 )

--- a/project/gameplay/objects/obstacles/solid-objects/outline_final.tres
+++ b/project/gameplay/objects/obstacles/solid-objects/outline_final.tres
@@ -1,4 +1,10 @@
-[gd_resource type="ShaderMaterial" load_steps=2 format=2]
+[gd_resource type="ShaderMaterial" load_steps=3 format=2]
+
+[sub_resource type="GDScript" id=2]
+script/source = "func _init():
+	self.shader.set_default_texture_param(\"distortion\", load(\"res://assets/images/effects/WaterDistortion.png\"))
+	self.shader.set_default_texture_param(\"noise\", load(\"res://assets/images/effects/noise.png\"))
+"
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -53,3 +59,4 @@ shader_param/wave_color = Color( 0.145098, 0.384314, 0.545098, 1 )
 shader_param/wave_scroll_speed = Vector2( 0.02, 0.01 )
 shader_param/distortion_strength = 0.3
 shader_param/aa_factor = 0.04
+script = SubResource( 2 )

--- a/project/menus/mode-select/button_shader.tres
+++ b/project/menus/mode-select/button_shader.tres
@@ -1,4 +1,10 @@
-[gd_resource type="ShaderMaterial" load_steps=2 format=2]
+[gd_resource type="ShaderMaterial" load_steps=3 format=2]
+
+[sub_resource type="GDScript" id=2]
+script/source = "func _init():
+	self.shader.set_default_texture_param(\"distortion\", load(\"res://assets/images/effects/WaterDistortion.png\"))
+	self.shader.set_default_texture_param(\"noise\", load(\"res://assets/images/effects/noise.png\"))
+"
 
 [sub_resource type="Shader" id=1]
 code = "shader_type canvas_item;
@@ -53,3 +59,4 @@ shader_param/wave_color = Color( 0.392157, 0.568627, 0.686275, 1 )
 shader_param/wave_scroll_speed = Vector2( 0.02, 0.01 )
 shader_param/distortion_strength = 0.3
 shader_param/aa_factor = 0.04
+script = SubResource( 2 )


### PR DESCRIPTION
Here's a workaround that restores the shaders to their former glory, now properly in its own pull request!

# Before

![Before](https://user-images.githubusercontent.com/97706756/231543025-6dd57b8e-ff04-4304-bc15-d05a8b575f1c.png)

# After

![After](https://user-images.githubusercontent.com/97706756/231543111-4e416508-0f8f-42b6-9d0f-25d981832097.png)
