### PR TITLE
Fix round screen breaking when game is paused

### DIFF
--- a/project/gameplay/Game.gd
+++ b/project/gameplay/Game.gd
@@ -19,11 +19,9 @@ var players
 var calling_check_winner = false
 var current_stage = 0
 var available_stages = []
-var can_pause = true
 
 
 func _ready():
-	add_to_group("pause_sync")
 	available_stages = range(0, stage_scenes.size())
 	test_setup()
 	var stage = get_first_stage().instance()
@@ -99,8 +97,6 @@ func transition_stage():
 	var rs = $RoundScreen
 	rs.show_round()
 	
-	can_pause = false
-	
 	yield(rs, "shown")
 	free_current_stage()
 	add_new_stage()
@@ -120,8 +116,6 @@ func transition_stage():
 	$PlayerHUD.hide_all()
 	
 	activate_players()
-	
-	can_pause = true
 	
 	var obstacles = get_node("Stage/Obstacles")
 	for obst in obstacles.get_children():
@@ -208,10 +202,6 @@ func check_winner():
 	yield(get_tree().create_timer(SHOW_ROUND_DELAY), "timeout")
 	calling_check_winner = false
 	transition_stage()
-
-
-func _allow_set_pause() -> bool:
-	return can_pause
 
 
 func _on_player_hook_shot(player, direction):

--- a/project/gameplay/hud/pause-screen/PauseScreen.gd
+++ b/project/gameplay/hud/pause-screen/PauseScreen.gd
@@ -46,6 +46,8 @@ func _input(event):
 	elif event.is_action_pressed("ui_cancel"):
 		PauseManager.set_pause(false)
 
+	get_tree().set_input_as_handled()
+
 
 func change_button(direction):
 	buttons[btn_index].set_frame(0)

--- a/project/gameplay/hud/round-screen/RoundScreen.tscn
+++ b/project/gameplay/hud/round-screen/RoundScreen.tscn
@@ -53,7 +53,6 @@ use_filter = true
 font_data = ExtResource( 11 )
 
 [node name="RoundScreen" type="CanvasLayer"]
-pause_mode = 2
 script = ExtResource( 1 )
 
 [node name="Background" type="TextureRect" parent="."]


### PR DESCRIPTION
# Before

The next round can't start if the game was paused just before the round screen drops in.

https://user-images.githubusercontent.com/97706756/231593249-56cb7912-ebb3-41ef-8b26-ab0c940a88d8.mp4

# After

The round screen reacts intuitively to pausing and the next round starts normally.

https://user-images.githubusercontent.com/97706756/231552929-b215274d-e715-46f0-baac-9aeca5b2a1cb.mp4

---

The messed-up shaders can also be seen in both videos. This is fixed in #295.