### PR TITLE
Fix title animation replaying if skipped

### DIFF
--- a/project/menus/main-menu/MainMenu.gd
+++ b/project/menus/main-menu/MainMenu.gd
@@ -67,7 +67,7 @@ func show_title():
 	if not Sound.menu_bgm.playing:
 		Sound.menu_bgm.play()
 	
-	tween.stop_all()
+	tween.remove_all()
 	title.rect_position = title_pos
 	$TitleAnticipationSFX.stop()
 	


### PR DESCRIPTION
A stopped tween is not removed by default, so the title position tween would start up again alongside the screen glow tween.